### PR TITLE
Allow uniquely identifying subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,25 @@ subscription = bus.subscribe(:order_created, OrderCreationEmailSubscription.new)
 bus.unsubscribe(subscription)
 ```
 
+Often you won't have a reference of the subscriber at hand. However, you can
+provide a subscription identifier for all the subscription methods we've seen
+so far.
+
+```ruby
+# For subscribe methods on the bus
+bus.subscribe(:order_created, OrderCreationEmailSubscription.new, id: :order_created_email)
+
+# For subscriber objects
+handle :order_created, with: :send_confirmation_email, id: :order_created_email
+```
+
+Then, you can use it to fetch the actual subscription:
+
+```ruby
+subscription = bus.subscription(:send_confirmation_email)
+bus.unsubscribe(subscription)
+```
+
 ### Registration
 
 Whenever you register an event, you get back an [`Omnes::Registry::Registration`](lib/omnes/registry.rb)
@@ -530,7 +549,8 @@ end
 bus.publish(:order_deleted, number: order.number) # `deletion_subscription` will run
 ```
 
-Remember that the array of created subscriptions is returned on `Omnes::Subscriber#subscribe_to`.
+Remember that you can get previous subscription references thanks to
+subscription identifiers. See [Unsubscribing](#unsubscribing) for details.
 
 There's also a specialized `Omnes::Bus#performing_nothing` method that runs no
 subscriptions for the duration of the block.

--- a/lib/omnes/bus.rb
+++ b/lib/omnes/bus.rb
@@ -229,6 +229,8 @@ module Omnes
     #
     # @return [Omnes::Subscription]
     def subscribe_with_matcher(matcher, callable = nil, id: Subscription.random_id, &block)
+      raise DuplicateSubscriptionIdError.new(id: id, bus: self) if subscription(id)
+
       callback = callable || block
       Subscription.new(matcher: matcher, callback: callback, id: id).tap do |subscription|
         @subscriptions << subscription

--- a/lib/omnes/errors.rb
+++ b/lib/omnes/errors.rb
@@ -98,4 +98,23 @@ module Omnes
       MSG
     end
   end
+
+  # Raised when given subscription id is already in use
+  class DuplicateSubscriptionIdError < Error
+    attr_reader :id, :bus
+
+    def initialize(id:, bus:)
+      @id = id
+      @bus = bus
+      super(default_message)
+    end
+
+    private
+
+    def default_message
+      <<~MSG
+        #{id} has already been used as a subscription identifier
+      MSG
+    end
+  end
 end

--- a/lib/omnes/errors.rb
+++ b/lib/omnes/errors.rb
@@ -117,4 +117,23 @@ module Omnes
       MSG
     end
   end
+
+  # Raised when trying to set an invalid subscription identifier
+  class InvalidSubscriptionNameError < Error
+    attr_reader :id
+
+    def initialize(id:)
+      @id = id
+      super(default_message)
+    end
+
+    private
+
+    def default_message
+      <<~MSG
+        #{id.inspect} is not a valid subscription identifier. Only symbols are
+        #allowed.
+      MSG
+    end
+  end
 end

--- a/lib/omnes/subscriber.rb
+++ b/lib/omnes/subscriber.rb
@@ -196,9 +196,9 @@ module Omnes
       # @param id [Symbol] Unique identifier for the subscription
       def handle(event_name, with:, id: Subscription.random_id)
         @_mutex.synchronize do
-          @_state.add_subscription_definition do |bus|
+          @_state.add_subscription_definition do |bus, instance|
             bus.registry.check_event_name(event_name)
-            [Subscription::SINGLE_EVENT_MATCHER.curry[event_name], Adapter.Type(with), id]
+            [Subscription::SINGLE_EVENT_MATCHER.curry[event_name], Adapter.Type(with), State.IdType(id).(instance)]
           end
         end
       end
@@ -209,8 +209,8 @@ module Omnes
       # @param id [Symbol] Unique identifier for the subscription
       def handle_all(with:, id: Subscription.random_id)
         @_mutex.synchronize do
-          @_state.add_subscription_definition do |_bus|
-            [Subscription::ALL_EVENTS_MATCHER, Adapter.Type(with), id]
+          @_state.add_subscription_definition do |_bus, instance|
+            [Subscription::ALL_EVENTS_MATCHER, Adapter.Type(with), State.IdType(id).(instance)]
           end
         end
       end
@@ -222,8 +222,8 @@ module Omnes
       # @param id [Symbol] Unique identifier for the subscription
       def handle_with_matcher(matcher, with:, id: Subscription.random_id)
         @_mutex.synchronize do
-          @_state.add_subscription_definition do |_bus|
-            [matcher, Adapter.Type(with), id]
+          @_state.add_subscription_definition do |_bus, instance|
+            [matcher, Adapter.Type(with), State.IdType(id).(instance)]
           end
         end
       end

--- a/lib/omnes/subscriber.rb
+++ b/lib/omnes/subscriber.rb
@@ -193,11 +193,12 @@ module Omnes
       #
       # @param event_name [Symbol]
       # @param with [Symbol, #call] Public method in the class or an adapter
-      def handle(event_name, with:)
+      # @param id [Symbol] Unique identifier for the subscription
+      def handle(event_name, with:, id: Subscription.random_id)
         @_mutex.synchronize do
           @_state.add_subscription_definition do |bus|
             bus.registry.check_event_name(event_name)
-            [Subscription::SINGLE_EVENT_MATCHER.curry[event_name], Adapter.Type(with)]
+            [Subscription::SINGLE_EVENT_MATCHER.curry[event_name], Adapter.Type(with), id]
           end
         end
       end
@@ -205,10 +206,11 @@ module Omnes
       # Handles all events
       #
       # @param with [Symbol, #call] Public method in the class or an adapter
-      def handle_all(with:)
+      # @param id [Symbol] Unique identifier for the subscription
+      def handle_all(with:, id: Subscription.random_id)
         @_mutex.synchronize do
           @_state.add_subscription_definition do |_bus|
-            [Subscription::ALL_EVENTS_MATCHER, Adapter.Type(with)]
+            [Subscription::ALL_EVENTS_MATCHER, Adapter.Type(with), id]
           end
         end
       end
@@ -217,10 +219,11 @@ module Omnes
       #
       # @param matcher [#call]
       # @param with [Symbol, #call] Public method in the class or an adapter
-      def handle_with_matcher(matcher, with:)
+      # @param id [Symbol] Unique identifier for the subscription
+      def handle_with_matcher(matcher, with:, id: Subscription.random_id)
         @_mutex.synchronize do
           @_state.add_subscription_definition do |_bus|
-            [matcher, Adapter.Type(with)]
+            [matcher, Adapter.Type(with), id]
           end
         end
       end

--- a/lib/omnes/subscriber/state.rb
+++ b/lib/omnes/subscriber/state.rb
@@ -10,6 +10,11 @@ module Omnes
     class State
       attr_reader :subscription_definitions, :calling_cache, :autodiscover_strategy
 
+      # @api private
+      def self.IdType(value)
+        value.respond_to?(:call) ? value : ->(_instance) { value }
+      end
+
       def initialize(autodiscover_strategy:, subscription_definitions: [], calling_cache: [])
         @subscription_definitions = subscription_definitions
         @calling_cache = calling_cache
@@ -21,7 +26,7 @@ module Omnes
 
         autodiscover_subscription_definitions(bus, instance) unless autodiscover_strategy.nil?
 
-        definitions = subscription_definitions.map { |defn| defn.(bus) }
+        definitions = subscription_definitions.map { |defn| defn.(bus, instance) }
 
         subscribe_definitions(definitions, bus, instance).tap do
           mark_as_called(bus, instance)

--- a/lib/omnes/subscriber/state.rb
+++ b/lib/omnes/subscriber/state.rb
@@ -50,18 +50,19 @@ module Omnes
           add_subscription_definition do |_bus|
             [
               Subscription::SINGLE_EVENT_MATCHER.curry[event_name],
-              Adapter.Type(Adapter::Method.new(method_name))
+              Adapter.Type(Adapter::Method.new(method_name)),
+              Subscription.random_id
             ]
           end
         end
       end
 
       def subscribe_definitions(definitions, bus, instance)
-        matcher_with_callbacks = definitions.map do |(matcher, adapter)|
-          [matcher, adapter.curry[instance]]
+        matcher_with_callbacks = definitions.map do |(matcher, adapter, id)|
+          [matcher, adapter.curry[instance], id]
         end
 
-        matcher_with_callbacks.map { |matcher, callback| bus.subscribe_with_matcher(matcher, callback) }
+        matcher_with_callbacks.map { |matcher, callback, id| bus.subscribe_with_matcher(matcher, callback, id: id) }
       end
     end
   end

--- a/lib/omnes/subscription.rb
+++ b/lib/omnes/subscription.rb
@@ -33,6 +33,8 @@ module Omnes
 
     # @api private
     def initialize(matcher:, callback:, id:)
+      raise Omnes::InvalidSubscriptionNameError.new(id: id) unless id.is_a?(Symbol)
+
       @matcher = matcher
       @callback = callback
       @id = id

--- a/lib/omnes/subscription.rb
+++ b/lib/omnes/subscription.rb
@@ -2,6 +2,7 @@
 
 require "benchmark"
 require "omnes/execution"
+require "securerandom"
 
 module Omnes
   # Subscription to an event
@@ -23,13 +24,18 @@ module Omnes
 
     ALL_EVENTS_MATCHER = ->(_candidate) { true }
 
-    # @api private
-    attr_reader :matcher, :callback
+    def self.random_id
+      SecureRandom.uuid.to_sym
+    end
 
     # @api private
-    def initialize(matcher:, callback:)
+    attr_reader :matcher, :callback, :id
+
+    # @api private
+    def initialize(matcher:, callback:, id:)
       @matcher = matcher
       @callback = callback
+      @id = id
     end
 
     # @api private

--- a/spec/support/shared_examples/bus.rb
+++ b/spec/support/shared_examples/bus.rb
@@ -213,6 +213,15 @@ RSpec.shared_examples "bus" do
       expect(subscription.callback.()).to be(:foo)
     end
 
+    it "can provide an identifier for the subscription" do
+      bus = subject.new
+      bus.register(:foo)
+
+      subscription = bus.subscribe_with_matcher(true_matcher, id: :foo_subscription) { :foo }
+
+      expect(bus.subscription(:foo_subscription)).to be(subscription)
+    end
+
     it "runs when matcher returns true" do
       dummy = counter.new
       bus = subject.new
@@ -267,6 +276,15 @@ RSpec.shared_examples "bus" do
 
       subscription = bus.subscriptions.first
       expect(subscription.callback.()).to be(:foo)
+    end
+
+    it "can provide an identifier for the subscription" do
+      bus = subject.new
+      bus.register(:foo)
+
+      subscription = bus.subscribe(:foo, id: :foo_subscription) { :foo }
+
+      expect(bus.subscription(:foo_subscription)).to be(subscription)
     end
 
     it "runs when published event matches" do
@@ -332,6 +350,15 @@ RSpec.shared_examples "bus" do
 
       subscription = bus.subscriptions.first
       expect(subscription.callback.()).to be(:foo)
+    end
+
+    it "can provide an identifier for the subscription" do
+      bus = subject.new
+      bus.register(:foo)
+
+      subscription = bus.subscribe_to_all(id: :foo_subscription) { :foo }
+
+      expect(bus.subscription(:foo_subscription)).to be(subscription)
     end
 
     it "runs for every event" do
@@ -447,6 +474,17 @@ RSpec.shared_examples "bus" do
       end
 
       expect(dummy.count).to be(0)
+    end
+  end
+
+  describe "#subscription" do
+    it "fetchs a subscription by its id" do
+      bus = subject.new
+      bus.register(:foo)
+
+      subscription = bus.subscribe(:foo, id: :foo_subs) { :foo }
+
+      expect(bus.subscription(:foo_subs)).to be(subscription)
     end
   end
 end

--- a/spec/support/shared_examples/bus.rb
+++ b/spec/support/shared_examples/bus.rb
@@ -222,6 +222,17 @@ RSpec.shared_examples "bus" do
       expect(bus.subscription(:foo_subscription)).to be(subscription)
     end
 
+    it "raises when given subscription id has already been used" do
+      bus = subject.new
+      bus.register(:foo)
+
+      bus.subscribe_with_matcher(true_matcher, id: :foo_subscription) { :foo }
+
+      expect {
+        bus.subscribe_with_matcher(true_matcher, id: :foo_subscription) { :foo }
+      }.to raise_error(Omnes::DuplicateSubscriptionIdError)
+    end
+
     it "runs when matcher returns true" do
       dummy = counter.new
       bus = subject.new
@@ -285,6 +296,17 @@ RSpec.shared_examples "bus" do
       subscription = bus.subscribe(:foo, id: :foo_subscription) { :foo }
 
       expect(bus.subscription(:foo_subscription)).to be(subscription)
+    end
+
+    it "raises when given subscription id has already been used" do
+      bus = subject.new
+      bus.register(:foo)
+
+      bus.subscribe(:foo, id: :foo_subscription) { :foo }
+
+      expect {
+        bus.subscribe(:foo, id: :foo_subscription) { :foo }
+      }.to raise_error(Omnes::DuplicateSubscriptionIdError)
     end
 
     it "runs when published event matches" do
@@ -359,6 +381,17 @@ RSpec.shared_examples "bus" do
       subscription = bus.subscribe_to_all(id: :foo_subscription) { :foo }
 
       expect(bus.subscription(:foo_subscription)).to be(subscription)
+    end
+
+    it "raises when given subscription id has already been used" do
+      bus = subject.new
+      bus.register(:foo)
+
+      bus.subscribe_to_all(id: :foo_subscription) { :foo }
+
+      expect {
+        bus.subscribe_to_all(id: :foo_subscription) { :foo }
+      }.to raise_error(Omnes::DuplicateSubscriptionIdError)
     end
 
     it "runs for every event" do

--- a/spec/unit/omnes/subscriber_spec.rb
+++ b/spec/unit/omnes/subscriber_spec.rb
@@ -97,6 +97,20 @@ RSpec.describe Omnes::Subscriber do
       expect(subscriber.called).to be(true)
     end
 
+    it "can provide id for the subscription" do
+      bus.register(:foo)
+      subscriber_class.class_eval do
+        handle :foo, with: :foo, id: :foo
+
+        def foo(_event); end
+      end
+      subscriber = subscriber_class.new
+
+      subscriptions = subscriber.subscribe_to(bus)
+
+      expect(bus.subscription(:foo)).to be(subscriptions[0])
+    end
+
     it "doesn't subscribe to other events" do
       bus.register(:foo)
       bus.register(:bar)
@@ -182,6 +196,20 @@ RSpec.describe Omnes::Subscriber do
       expect(subscriber.called).to be(true)
     end
 
+    it "can provide id for the subscription" do
+      bus.register(:foo)
+      subscriber_class.class_eval do
+        handle_all with: :foo, id: :all
+
+        def foo(_event); end
+      end
+      subscriber = subscriber_class.new
+
+      subscriptions = subscriber.subscribe_to(bus)
+
+      expect(bus.subscription(:all)).to be(subscriptions[0])
+    end
+
     it "builds the callback from a matching method when given a symbol" do
       bus.register(:foo)
       subscriber_class.class_eval do
@@ -237,6 +265,22 @@ RSpec.describe Omnes::Subscriber do
       expect(subscriber.called).to be(true)
     ensure
       Object.send(:remove_const, :TRUE_MATCHER)
+    end
+
+    it "can provide id for the subscription" do
+      bus.register(:foo)
+      subscriber_class.class_eval do
+        ::TRUE_MATCHER = ->(_candidate) { true }
+
+        handle_with_matcher TRUE_MATCHER, with: :foo, id: :foo
+
+        def foo(_event); end
+      end
+      subscriber = subscriber_class.new
+
+      subscriptions = subscriber.subscribe_to(bus)
+
+      expect(bus.subscription(:foo)).to be(subscriptions[0])
     end
 
     it "builds the callback from a matching method when given a symbol" do

--- a/spec/unit/omnes/subscriber_spec.rb
+++ b/spec/unit/omnes/subscriber_spec.rb
@@ -448,7 +448,7 @@ RSpec.describe Omnes::Subscriber do
     it "can subscribe multiple instances to the same bus" do
       bus.register(:foo)
       subscriber_class.class_eval do
-        handle :foo, with: :foo, id: ->(instance) { instance.object_id }
+        handle :foo, with: :foo, id: ->(instance) { instance.object_id.to_s.to_sym }
 
         def foo(_event)
           @called = true

--- a/spec/unit/omnes/subscription_spec.rb
+++ b/spec/unit/omnes/subscription_spec.rb
@@ -35,13 +35,13 @@ RSpec.describe Omnes::Subscription do
 
   describe "#call" do
     it "returns an execution instance" do
-      subscription = described_class.new(matcher: true_matcher, callback: proc {})
+      subscription = described_class.new(matcher: true_matcher, callback: proc {}, id: :id)
 
       expect(subscription.(:event)).to be_a(Omnes::Execution)
     end
 
     it "binds the event and sets execution's result" do
-      subscription = described_class.new(matcher: true_matcher, callback: ->(event) { event[:foo] })
+      subscription = described_class.new(matcher: true_matcher, callback: ->(event) { event[:foo] }, id: :id)
 
       execution = subscription.(foo: :bar)
 
@@ -49,7 +49,7 @@ RSpec.describe Omnes::Subscription do
     end
 
     it "sets itself as the execution subscription" do
-      subscription = described_class.new(matcher: true_matcher, callback: proc { "foo" })
+      subscription = described_class.new(matcher: true_matcher, callback: proc { "foo" }, id: :id)
 
       execution = subscription.(:event)
 
@@ -57,7 +57,7 @@ RSpec.describe Omnes::Subscription do
     end
 
     it "sets the execution's benchmark" do
-      subscription = described_class.new(matcher: true_matcher, callback: proc { "foo" })
+      subscription = described_class.new(matcher: true_matcher, callback: proc { "foo" }, id: :id)
 
       execution = subscription.(:event)
 
@@ -67,13 +67,13 @@ RSpec.describe Omnes::Subscription do
 
   describe "#matches?" do
     it "return true when matcher returns true for given candidate" do
-      subscription = described_class.new(matcher: true_matcher, callback: -> {})
+      subscription = described_class.new(matcher: true_matcher, callback: -> {}, id: :id)
 
       expect(subscription.matches?(:foo)).to be(true)
     end
 
     it "return false when matcher returns false for given candidate" do
-      subscription = described_class.new(matcher: false_matcher, callback: -> {})
+      subscription = described_class.new(matcher: false_matcher, callback: -> {}, id: :id)
 
       expect(subscription.matches?(:bar)).to be(false)
     end
@@ -81,7 +81,7 @@ RSpec.describe Omnes::Subscription do
 
   describe "#subscriptions" do
     it "returns a list containing only itself" do
-      subscription = described_class.new(matcher: true_matcher, callback: -> {})
+      subscription = described_class.new(matcher: true_matcher, callback: -> {}, id: :id)
 
       expect(subscription.subscriptions).to eq([subscription])
     end

--- a/spec/unit/omnes/subscription_spec.rb
+++ b/spec/unit/omnes/subscription_spec.rb
@@ -33,6 +33,14 @@ RSpec.describe Omnes::Subscription do
     end
   end
 
+  describe "#initialize" do
+    it "raises when id is not a Symbol" do
+      expect {
+        described_class.new(matcher: true_matcher, callback: proc {}, id: 1)
+      }.to raise_error(Omnes::InvalidSubscriptionNameError)
+    end
+  end
+
   describe "#call" do
     it "returns an execution instance" do
       subscription = described_class.new(matcher: true_matcher, callback: proc {}, id: :id)


### PR DESCRIPTION
We add an `id:` param to all the methods to create subscriptions. We can
use it to fetch a given subscription from the bus when a reference to it
is no longer available. Example:

```ruby
subscription = bus.subscribe(:foo, id: :foo_subscription) { do_something }
bus.subscription(:foo) == subscription # => true
```

That's very useful as it allows us to make the event bus the only global
piece in the code and use it for testing purposes like in the
`Omnes::Bus#performing_only` method.

As it's possible to subscribe multiple instances of a subscriber class
to the same bus, we also add the possibility of making IDs dependent on
the given instance. For those cases, the id must be given as a lambda
taking the instance as argument:

```ruby
handle :foo, with: :foo, id: ->(instance) { :"foo_#{instance.object_id}" }
```

Lastly, we force identifiers to be a Symbol.