### PR TITLE
Bind a publication context to subscriptions

### DIFF
--- a/lib/omnes/publication.rb
+++ b/lib/omnes/publication.rb
@@ -19,25 +19,16 @@ module Omnes
     # @return [Array<Omnes::Execution>]
     attr_reader :executions
 
-    # Location for the event caller
+    # Publication context, shared by all triggered executions
     #
-    # It's usually set by {Omnes::Bus#publish}, and it points to the caller of
-    # that method.
-    #
-    # @return [Thread::Backtrace::Location]
-    attr_reader :caller_location
-
-    # Time of the event publication
-    #
-    # @return [Time]
-    attr_reader :time
+    # @return [Omnes::PublicationContext]
+    attr_reader :context
 
     # @api private
-    def initialize(event:, executions:, caller_location:, time:)
+    def initialize(event:, executions:, context:)
       @event = event
       @executions = executions
-      @caller_location = caller_location
-      @time = time
+      @context = context
     end
   end
 end

--- a/lib/omnes/publication_context.rb
+++ b/lib/omnes/publication_context.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Omnes
+  # Context for an event publication
+  #
+  # An instance of this class is shared between all the executions that are
+  # triggered by the publication of a given event. It's provided to the
+  # subscriptions as their second argument when they take it.
+  #
+  # This class is useful mainly for debugging and logging purposes.
+  class PublicationContext
+    # Location for the event publisher
+    #
+    # It's set by {Omnes::Bus#publish}, and it points to the caller of that
+    # method.
+    #
+    # @return [Thread::Backtrace::Location]
+    attr_reader :caller_location
+
+    # Time of the event publication
+    #
+    # @return [Time]
+    attr_reader :time
+
+    # @api private
+    def initialize(caller_location:, time:)
+      @caller_location = caller_location
+      @time = time
+    end
+
+    # Serialized version of a publication context
+    #
+    # @return Hash<String, String>
+    def serialized
+      {
+        "caller_location" => caller_location.to_s,
+        "time" => time.to_s
+      }
+    end
+  end
+end

--- a/lib/omnes/subscriber/adapter/active_job.rb
+++ b/lib/omnes/subscriber/adapter/active_job.rb
@@ -52,8 +52,8 @@ module Omnes
         end
 
         # @api private
-        def self.call(instance, event)
-          self.[].(instance, event)
+        def self.call(instance, event, publication_context)
+          self.[].(instance, event, publication_context)
         end
 
         # @api private
@@ -64,8 +64,12 @@ module Omnes
             @serializer = serializer
           end
 
-          def call(instance, event)
-            instance.class.perform_later(serializer.(event))
+          def call(instance, event, publication_context)
+            if Subscription.takes_publication_context?(instance.method(:perform))
+              instance.class.perform_later(serializer.(event), publication_context.serialized)
+            else
+              instance.class.perform_later(serializer.(event))
+            end
           end
         end
       end

--- a/lib/omnes/subscriber/adapter/method.rb
+++ b/lib/omnes/subscriber/adapter/method.rb
@@ -7,7 +7,7 @@ module Omnes
     module Adapter
       # Builds a callback from a method of the instance
       #
-      # You can use instance of this class as the adapter:
+      # You can use an instance of this class as the adapter:
       #
       # ```ruby
       # handle :foo, with: Adapter::Method.new(:foo)
@@ -29,7 +29,7 @@ module Omnes
         def call(instance)
           check_method(instance)
 
-          ->(event) { instance.method(name).(event) }
+          instance.method(name)
         end
 
         private

--- a/spec/unit/omnes/publication_context_spec.rb
+++ b/spec/unit/omnes/publication_context_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "omnes/publication_context"
+
+RSpec.describe Omnes::PublicationContext do
+  describe ".serialized" do
+    it "serializes caller_location as string" do
+      context = described_class.new(caller_location: caller_locations(0)[0], time: Time.now)
+
+      expect(context.serialized["caller_location"]).to include(__FILE__)
+    end
+
+    it "serializes time as string" do
+      context = described_class.new(caller_location: caller_locations(0)[0], time: Time.new(2022, 10, 10))
+
+      expect(context.serialized["time"]).to include("2022-10-10")
+    end
+  end
+end


### PR DESCRIPTION
That improves debugging by yielding a second optional argument to
subscription blocks. That argument is an instance of
`Omnes::PublicationContext`, referencing the publisher's location and
the publication time.

```ruby
bus.subscribe(:foo) do |event, publication_context|
  # debugging
  abort publication_context.inspect
end
```

If they want to support it, adapters need to be aware to dispatch the
second argument if present. As such, current adapters have been adapted.
`Omnes::PublicationContext` contains a `#serialized` method that can be
called before dispatching async adapters.