### PR TITLE
Add Omnes::Bus#clear

### DIFF
--- a/lib/omnes/bus.rb
+++ b/lib/omnes/bus.rb
@@ -287,6 +287,18 @@ module Omnes
       subscriptions.find { |subscription| subscription.id == id }
     end
 
+    # Clears all registered events and subscriptions
+    #
+    # Useful for code reloading.
+    #
+    # @return [Omnes::Bus]
+    def clear
+      tap do
+        @subscriptions = []
+        @registry = Registry.new
+      end
+    end
+
     private
 
     def execute_subscriptions_for_event(event, publication_context)

--- a/spec/support/shared_examples/bus.rb
+++ b/spec/support/shared_examples/bus.rb
@@ -550,4 +550,29 @@ RSpec.shared_examples "bus" do
       expect(bus.subscription(:foo_subs)).to be(subscription)
     end
   end
+
+  describe "#clear" do
+    it "removes subscriptions" do
+      bus = subject.new
+      bus.register(:foo)
+      bus.subscribe(:foo) { :foo }
+
+      bus.clear
+
+      expect(bus.subscriptions.empty?).to be(true)
+    end
+
+    it "uses a pristine register" do
+      bus = subject.new
+
+      expect(bus.registry).not_to be(bus.clear.registry)
+    end
+
+    it "doesn't keep registrations in the new registry" do
+      bus = subject.new
+      bus.register(:foo)
+
+      expect(bus.clear.registry.registered?(:foo)).to be(false)
+    end
+  end
 end


### PR DESCRIPTION
That will empty the event bus from all registered event and
subscriptions.

It's something useful in regards of implementing autoloading strategies.