### PR TITLE
Support Ruby 2.5 & 2.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1']
+        ruby-version: ['2.5', '2.6', '2.7', '3.0', '3.1']
 
     steps:
     - name: Checkout repository

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 2.5
   NewCops: enable
   SuggestExtensions: false
 

--- a/lib/omnes.rb
+++ b/lib/omnes.rb
@@ -44,7 +44,12 @@ module Omnes
     klass.define_method(:omnes_bus) { @omnes_bus ||= Bus.new(cal_loc_start: 2) }
     Bus.instance_methods(false).each do |method|
       klass.define_method(method) do |*args, **kwargs, &block|
-        omnes_bus.send(method, *args, **kwargs, &block)
+        # TODO: Forward with ... once we deprecate ruby 2.5 & 2.6
+        if kwargs.any?
+          omnes_bus.send(method, *args, **kwargs, &block)
+        else
+          omnes_bus.send(method, *args, &block)
+        end
       end
     end
   end

--- a/lib/omnes/errors.rb
+++ b/lib/omnes/errors.rb
@@ -18,7 +18,7 @@ module Omnes
     def default_message
       <<~MSG
         '#{event_name}' event is not registered.
-        #{suggestions_message}
+        #{suggestions_message if defined?(DidYouMean::PlainFormatter)}
 
         All known events are:
 

--- a/omnes.gemspec
+++ b/omnes.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   MSG
   spec.homepage = "https://github.com/nebulab/omnes"
   spec.license = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.7.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
 
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
 
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "activejob", "~> 7.0"
+  spec.add_development_dependency "activejob"
   spec.add_development_dependency "redcarpet", "~> 3.5"
   spec.add_development_dependency "sidekiq", "~> 6.4"
   spec.add_development_dependency "yard", "~> 0.9"

--- a/spec/unit/omnes/registry_spec.rb
+++ b/spec/unit/omnes/registry_spec.rb
@@ -128,13 +128,15 @@ RSpec.describe Omnes::Registry do
       }.to raise_error(/'bar', 'baz'/)
     end
 
-    it "hints on the event name on the error message" do
-      registry = described_class.new
-      registry.register(:foo)
+    if defined?(DidYouMean::PlainFormatter)
+      it "hints on the event name on the error message" do
+        registry = described_class.new
+        registry.register(:foo)
 
-      expect {
-        registry.check_event_name(:fo)
-      }.to raise_error(/Did you mean\?  foo/)
+        expect {
+          registry.check_event_name(:fo)
+        }.to raise_error(/Did you mean\?  foo/)
+      end
     end
   end
 end

--- a/spec/unit/omnes/subscriber/adapter/active_job_spec.rb
+++ b/spec/unit/omnes/subscriber/adapter/active_job_spec.rb
@@ -30,8 +30,9 @@ RSpec.describe Omnes::Subscriber::Adapter::ActiveJob do
 
     bus.register(:create_foo)
     Subscriber.new.subscribe_to(bus)
+    event = Struct.new(:omnes_event_name, :payload).new(:create_foo, "id" => 1, "attributes" => { "name" => "foo" })
 
-    bus.publish(:create_foo, "id" => 1, "attributes" => { "name" => "foo" })
+    bus.publish(event)
     perform_enqueued_jobs
 
     expect(FOO_TABLE[1]).to eq("name" => "foo")

--- a/spec/unit/omnes/subscriber/adapter/sidekiq_spec.rb
+++ b/spec/unit/omnes/subscriber/adapter/sidekiq_spec.rb
@@ -28,8 +28,9 @@ RSpec.describe Omnes::Subscriber::Adapter::Sidekiq do
 
     bus.register(:create_foo)
     Subscriber.new.subscribe_to(bus)
+    event = Struct.new(:omnes_event_name, :payload).new(:create_foo, "id" => 1, "attributes" => { "name" => "foo" })
 
-    bus.publish(:create_foo, "id" => 1, "attributes" => { "name" => "foo" })
+    bus.publish(event)
 
     expect(FOO_TABLE[1]).to eq("name" => "foo")
   ensure
@@ -109,10 +110,11 @@ RSpec.describe Omnes::Subscriber::Adapter::Sidekiq do
 
     bus.register(:create_foo)
     Subscriber.new.subscribe_to(bus)
+    event = Struct.new(:omnes_event_name, :payload).new(:create_foo, "id" => 1, "attributes" => { "name" => "foo" })
 
     expect(Subscriber).to receive(:perform_in).with(60, any_args).and_call_original
 
-    bus.publish(:create_foo, "id" => 1, "attributes" => { "name" => "foo" })
+    bus.publish(event)
 
     expect(FOO_TABLE[1]).to eq("name" => "foo")
   ensure


### PR DESCRIPTION
Omnes was born as an extraction from
[Solidus](https://github.com/solidusio/solidus) and it's used there to
provide pub/sub support. Current Solidus still supports Ruby 2.5 & 2.6.
We'll deprecate here as soon as they're deprecated on Solidus (which
should happen in next major).

An edge case that won't work on those versions is passing a serialized
payload when publishing an unstructured event, as it'll require the
kwargs keys to be Symbols. That's something not used on Solidus, so we
don't make any changes to support it. For those cases, the workaround is
publishing an event instance with the `#payload` method.