### PR TITLE
Stop supporting old rubies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2']
+        ruby-version: ['3.0', '3.1', '3.2']
 
     steps:
     - name: Checkout repository

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 3.0
   NewCops: enable
   SuggestExtensions: false
 

--- a/lib/omnes.rb
+++ b/lib/omnes.rb
@@ -44,12 +44,7 @@ module Omnes
     klass.define_method(:omnes_bus) { @omnes_bus ||= Bus.new(cal_loc_start: 2) }
     Bus.instance_methods(false).each do |method|
       klass.define_method(method) do |*args, **kwargs, &block|
-        # TODO: Forward with ... once we deprecate ruby 2.5 & 2.6
-        if kwargs.any?
-          omnes_bus.send(method, *args, **kwargs, &block)
-        else
-          omnes_bus.send(method, *args, &block)
-        end
+        omnes_bus.send(method, *args, **kwargs, &block)
       end
     end
   end

--- a/omnes.gemspec
+++ b/omnes.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   MSG
   spec.homepage = "https://github.com/nebulab/omnes"
   spec.license = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.0.0")
 
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
 


### PR DESCRIPTION
Ruby 2.5, 2.6 & 2.7 are already EOL.

The comment about using "..." was wrong, as that's not valid syntax for block arguments, but we can still simplify the code.
